### PR TITLE
Grammar: Add support for "C" and "R" change types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -25,7 +25,7 @@ module.exports = grammar({
 
     change: ($) =>
       seq(
-        field('type', choice("A", "M", "D")),
+        field('type', choice("A", "M", "D", "C", "R")),
         " ",
         $.filepath,
       ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -4,5 +4,7 @@
 (change type: "A" @diff.plus)
 (change type: "D" @diff.minus)
 (change type: "M" @diff.delta)
+(change type: "C" @diff.plus)
+(change type: "R" @diff.delta)
 
 (comment) @comment

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -64,6 +64,14 @@
               {
                 "type": "STRING",
                 "value": "D"
+              },
+              {
+                "type": "STRING",
+                "value": "C"
+              },
+              {
+                "type": "STRING",
+                "value": "R"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12,11 +12,19 @@
             "named": false
           },
           {
+            "type": "C",
+            "named": false
+          },
+          {
             "type": "D",
             "named": false
           },
           {
             "type": "M",
+            "named": false
+          },
+          {
+            "type": "R",
             "named": false
           }
         ]
@@ -119,6 +127,10 @@
     "named": false
   },
   {
+    "type": "C",
+    "named": false
+  },
+  {
     "type": "D",
     "named": false
   },
@@ -136,6 +148,10 @@
   },
   {
     "type": "M",
+    "named": false
+  },
+  {
+    "type": "R",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,9 +7,9 @@
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 38
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 27
+#define SYMBOL_COUNT 29
 #define ALIAS_COUNT 2
-#define TOKEN_COUNT 17
+#define TOKEN_COUNT 19
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 5
@@ -20,30 +20,32 @@ enum ts_symbol_identifiers {
   anon_sym_A = 2,
   anon_sym_M = 3,
   anon_sym_D = 4,
-  anon_sym_SPACE = 5,
-  aux_sym_filepath_token1 = 6,
-  aux_sym_scissors_token1 = 7,
-  anon_sym_JJ_COLONdescribe = 8,
-  anon_sym_NULL = 9,
-  anon_sym_JJ_COLON = 10,
-  aux_sym__change_comment_token1 = 11,
-  aux_sym__text_comment_token1 = 12,
-  aux_sym_text_token1 = 13,
-  anon_sym_J = 14,
-  anon_sym_JJ = 15,
-  aux_sym_text_token2 = 16,
-  sym_document = 17,
-  sym_change = 18,
-  sym_filepath = 19,
-  sym_scissors = 20,
-  sym_comment = 21,
-  sym__change_comment = 22,
-  sym__text_comment = 23,
-  sym_text = 24,
-  aux_sym_document_repeat1 = 25,
-  aux_sym_scissors_repeat1 = 26,
-  alias_sym_comment_text = 27,
-  alias_sym_scissors_inner = 28,
+  anon_sym_C = 5,
+  anon_sym_R = 6,
+  anon_sym_SPACE = 7,
+  aux_sym_filepath_token1 = 8,
+  aux_sym_scissors_token1 = 9,
+  anon_sym_JJ_COLONdescribe = 10,
+  anon_sym_NULL = 11,
+  anon_sym_JJ_COLON = 12,
+  aux_sym__change_comment_token1 = 13,
+  aux_sym__text_comment_token1 = 14,
+  aux_sym_text_token1 = 15,
+  anon_sym_J = 16,
+  anon_sym_JJ = 17,
+  aux_sym_text_token2 = 18,
+  sym_document = 19,
+  sym_change = 20,
+  sym_filepath = 21,
+  sym_scissors = 22,
+  sym_comment = 23,
+  sym__change_comment = 24,
+  sym__text_comment = 25,
+  sym_text = 26,
+  aux_sym_document_repeat1 = 27,
+  aux_sym_scissors_repeat1 = 28,
+  alias_sym_comment_text = 29,
+  alias_sym_scissors_inner = 30,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -52,6 +54,8 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_A] = "A",
   [anon_sym_M] = "M",
   [anon_sym_D] = "D",
+  [anon_sym_C] = "C",
+  [anon_sym_R] = "R",
   [anon_sym_SPACE] = " ",
   [aux_sym_filepath_token1] = "filepath_token1",
   [aux_sym_scissors_token1] = "comment",
@@ -84,6 +88,8 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_A] = anon_sym_A,
   [anon_sym_M] = anon_sym_M,
   [anon_sym_D] = anon_sym_D,
+  [anon_sym_C] = anon_sym_C,
+  [anon_sym_R] = anon_sym_R,
   [anon_sym_SPACE] = anon_sym_SPACE,
   [aux_sym_filepath_token1] = aux_sym_filepath_token1,
   [aux_sym_scissors_token1] = sym_comment,
@@ -128,6 +134,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_D] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_C] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_R] = {
     .visible = true,
     .named = false,
   },
@@ -326,63 +340,67 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 0:
       if (eof) ADVANCE(21);
       ADVANCE_MAP(
-        0, 42,
+        0, 44,
         '\n', 22,
-        '\r', 47,
-        ' ', 26,
-        ':', 46,
+        '\r', 49,
+        ' ', 28,
+        ':', 48,
         'A', 23,
+        'C', 26,
         'D', 25,
-        'J', 50,
+        'J', 52,
         'M', 24,
+        'R', 27,
       );
-      if (lookahead != 0) ADVANCE(46);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 1:
-      if ((!eof && lookahead == 00)) ADVANCE(43);
-      if (lookahead == 'J') ADVANCE(30);
+      if ((!eof && lookahead == 00)) ADVANCE(45);
+      if (lookahead == 'J') ADVANCE(32);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 2:
       if (lookahead == '\n') ADVANCE(22);
       END_STATE();
     case 3:
       if (lookahead == '\n') ADVANCE(22);
-      if (lookahead == '\r') ADVANCE(47);
-      if (lookahead == ' ') ADVANCE(45);
+      if (lookahead == '\r') ADVANCE(49);
+      if (lookahead == ' ') ADVANCE(47);
       if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(45);
+          lookahead == '\f') ADVANCE(47);
       if (lookahead != 0 &&
           lookahead != 'A' &&
           lookahead != 'D' &&
-          lookahead != 'M') ADVANCE(46);
+          lookahead != 'M') ADVANCE(48);
       END_STATE();
     case 4:
       if (lookahead == '\n') ADVANCE(22);
-      if (lookahead == '\r') ADVANCE(54);
+      if (lookahead == '\r') ADVANCE(56);
       if (lookahead != 0 &&
-          lookahead != ':') ADVANCE(53);
+          lookahead != ':') ADVANCE(55);
       END_STATE();
     case 5:
       if (lookahead == '\n') ADVANCE(22);
       if (lookahead == '\r') ADVANCE(2);
-      if (lookahead != 0) ADVANCE(39);
+      if (lookahead != 0) ADVANCE(41);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(40);
+      if (lookahead == '\n') ADVANCE(42);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(40);
+      if (lookahead == '\n') ADVANCE(42);
       if (lookahead == '\r') ADVANCE(6);
       END_STATE();
     case 8:
-      if (lookahead == ' ') ADVANCE(26);
+      if (lookahead == ' ') ADVANCE(28);
       if (lookahead == 'A') ADVANCE(23);
+      if (lookahead == 'C') ADVANCE(26);
       if (lookahead == 'D') ADVANCE(25);
       if (lookahead == 'M') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(46);
+      if (lookahead == 'R') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 9:
       if (lookahead == '-') ADVANCE(17);
@@ -420,9 +438,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 20:
       if (eof) ADVANCE(21);
       if (lookahead == '\n') ADVANCE(22);
-      if (lookahead == '\r') ADVANCE(49);
-      if (lookahead == 'J') ADVANCE(51);
-      if (lookahead != 0) ADVANCE(48);
+      if (lookahead == '\r') ADVANCE(51);
+      if (lookahead == 'J') ADVANCE(53);
+      if (lookahead != 0) ADVANCE(50);
       END_STATE();
     case 21:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -440,155 +458,161 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(anon_sym_D);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(anon_sym_SPACE);
+      ACCEPT_TOKEN(anon_sym_C);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == ' ') ADVANCE(33);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+      ACCEPT_TOKEN(anon_sym_R);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == ' ') ADVANCE(41);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+      ACCEPT_TOKEN(anon_sym_SPACE);
       END_STATE();
     case 29:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == ':') ADVANCE(27);
+      if (lookahead == ' ') ADVANCE(35);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 30:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'J') ADVANCE(29);
+      if (lookahead == ' ') ADVANCE(43);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'b') ADVANCE(35);
+      if (lookahead == ':') ADVANCE(29);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'c') ADVANCE(37);
+      if (lookahead == 'J') ADVANCE(31);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'd') ADVANCE(34);
+      if (lookahead == 'b') ADVANCE(37);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'e') ADVANCE(38);
+      if (lookahead == 'c') ADVANCE(39);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'e') ADVANCE(28);
+      if (lookahead == 'd') ADVANCE(36);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'i') ADVANCE(31);
+      if (lookahead == 'e') ADVANCE(40);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 'r') ADVANCE(36);
+      if (lookahead == 'e') ADVANCE(30);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
-      if (lookahead == 's') ADVANCE(32);
+      if (lookahead == 'i') ADVANCE(33);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_filepath_token1);
+      if (lookahead == 'r') ADVANCE(38);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(aux_sym_scissors_token1);
+      ACCEPT_TOKEN(aux_sym_filepath_token1);
+      if (lookahead == 's') ADVANCE(34);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
     case 41:
+      ACCEPT_TOKEN(aux_sym_filepath_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(41);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(aux_sym_scissors_token1);
+      END_STATE();
+    case 43:
       ACCEPT_TOKEN(anon_sym_JJ_COLONdescribe);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
-    case 42:
+    case 44:
       ACCEPT_TOKEN(anon_sym_NULL);
       END_STATE();
-    case 43:
+    case 45:
       ACCEPT_TOKEN(anon_sym_NULL);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(39);
+          lookahead != '\r') ADVANCE(41);
       END_STATE();
-    case 44:
+    case 46:
       ACCEPT_TOKEN(anon_sym_JJ_COLON);
       if (lookahead == ' ') ADVANCE(13);
       END_STATE();
-    case 45:
+    case 47:
       ACCEPT_TOKEN(aux_sym__change_comment_token1);
       if (lookahead == 0x0b ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(45);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(aux_sym__text_comment_token1);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym__text_comment_token1);
-      if (lookahead == '\n') ADVANCE(22);
+          lookahead == ' ') ADVANCE(47);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(aux_sym_text_token1);
+      ACCEPT_TOKEN(aux_sym__text_comment_token1);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(aux_sym_text_token1);
+      ACCEPT_TOKEN(aux_sym__text_comment_token1);
       if (lookahead == '\n') ADVANCE(22);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(anon_sym_J);
+      ACCEPT_TOKEN(aux_sym_text_token1);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(anon_sym_J);
-      if (lookahead == 'J') ADVANCE(52);
+      ACCEPT_TOKEN(aux_sym_text_token1);
+      if (lookahead == '\n') ADVANCE(22);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(anon_sym_JJ);
-      if (lookahead == ':') ADVANCE(44);
+      ACCEPT_TOKEN(anon_sym_J);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(aux_sym_text_token2);
+      ACCEPT_TOKEN(anon_sym_J);
+      if (lookahead == 'J') ADVANCE(54);
       END_STATE();
     case 54:
+      ACCEPT_TOKEN(anon_sym_JJ);
+      if (lookahead == ':') ADVANCE(46);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(aux_sym_text_token2);
+      END_STATE();
+    case 56:
       ACCEPT_TOKEN(aux_sym_text_token2);
       if (lookahead == '\n') ADVANCE(22);
       END_STATE();
@@ -603,12 +627,12 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [2] = {.lex_state = 20},
   [3] = {.lex_state = 20},
   [4] = {.lex_state = 20},
-  [5] = {.lex_state = 20},
+  [5] = {.lex_state = 8},
   [6] = {.lex_state = 20},
   [7] = {.lex_state = 20},
   [8] = {.lex_state = 20},
-  [9] = {.lex_state = 3},
-  [10] = {.lex_state = 8},
+  [9] = {.lex_state = 20},
+  [10] = {.lex_state = 3},
   [11] = {.lex_state = 1},
   [12] = {.lex_state = 1},
   [13] = {.lex_state = 1},
@@ -645,6 +669,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_A] = ACTIONS(1),
     [anon_sym_M] = ACTIONS(1),
     [anon_sym_D] = ACTIONS(1),
+    [anon_sym_C] = ACTIONS(1),
+    [anon_sym_R] = ACTIONS(1),
     [anon_sym_SPACE] = ACTIONS(1),
     [anon_sym_NULL] = ACTIONS(1),
     [aux_sym__text_comment_token1] = ACTIONS(1),
@@ -721,17 +747,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_text_token1,
       anon_sym_J,
       anon_sym_JJ,
-  [72] = 2,
-    ACTIONS(45), 3,
-      ts_builtin_sym_end,
-      aux_sym_document_token1,
-      aux_sym_scissors_token1,
-    ACTIONS(47), 4,
-      anon_sym_JJ_COLON,
-      aux_sym_text_token1,
-      anon_sym_J,
-      anon_sym_JJ,
-  [84] = 2,
+  [72] = 3,
+    ACTIONS(47), 1,
+      aux_sym__text_comment_token1,
+    STATE(20), 1,
+      sym_change,
+    ACTIONS(45), 5,
+      anon_sym_A,
+      anon_sym_M,
+      anon_sym_D,
+      anon_sym_C,
+      anon_sym_R,
+  [86] = 2,
     ACTIONS(49), 3,
       ts_builtin_sym_end,
       aux_sym_document_token1,
@@ -741,18 +768,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_text_token1,
       anon_sym_J,
       anon_sym_JJ,
-  [96] = 2,
-    ACTIONS(21), 3,
+  [98] = 2,
+    ACTIONS(53), 3,
       ts_builtin_sym_end,
       aux_sym_document_token1,
       aux_sym_scissors_token1,
-    ACTIONS(53), 4,
+    ACTIONS(55), 4,
       anon_sym_JJ_COLON,
       aux_sym_text_token1,
       anon_sym_J,
       anon_sym_JJ,
-  [108] = 2,
-    ACTIONS(55), 3,
+  [110] = 2,
+    ACTIONS(21), 3,
       ts_builtin_sym_end,
       aux_sym_document_token1,
       aux_sym_scissors_token1,
@@ -761,26 +788,27 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_text_token1,
       anon_sym_J,
       anon_sym_JJ,
-  [120] = 4,
-    ACTIONS(59), 1,
+  [122] = 2,
+    ACTIONS(59), 3,
+      ts_builtin_sym_end,
       aux_sym_document_token1,
-    ACTIONS(61), 1,
-      aux_sym__change_comment_token1,
+      aux_sym_scissors_token1,
+    ACTIONS(61), 4,
+      anon_sym_JJ_COLON,
+      aux_sym_text_token1,
+      anon_sym_J,
+      anon_sym_JJ,
+  [134] = 4,
     ACTIONS(63), 1,
+      aux_sym_document_token1,
+    ACTIONS(65), 1,
+      aux_sym__change_comment_token1,
+    ACTIONS(67), 1,
       aux_sym__text_comment_token1,
     STATE(25), 2,
       sym__change_comment,
       sym__text_comment,
-  [134] = 3,
-    ACTIONS(67), 1,
-      aux_sym__text_comment_token1,
-    STATE(20), 1,
-      sym_change,
-    ACTIONS(65), 3,
-      anon_sym_A,
-      anon_sym_M,
-      anon_sym_D,
-  [146] = 4,
+  [148] = 4,
     ACTIONS(69), 1,
       aux_sym_filepath_token1,
     ACTIONS(71), 1,
@@ -789,7 +817,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_NULL,
     STATE(13), 1,
       aux_sym_scissors_repeat1,
-  [159] = 4,
+  [161] = 4,
     ACTIONS(69), 1,
       aux_sym_filepath_token1,
     ACTIONS(75), 1,
@@ -798,7 +826,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_NULL,
     STATE(11), 1,
       aux_sym_scissors_repeat1,
-  [172] = 3,
+  [174] = 3,
     ACTIONS(79), 1,
       aux_sym_filepath_token1,
     STATE(13), 1,
@@ -806,88 +834,88 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(82), 2,
       anon_sym_JJ_COLONdescribe,
       anon_sym_NULL,
-  [183] = 1,
+  [185] = 1,
     ACTIONS(82), 3,
       aux_sym_filepath_token1,
       anon_sym_JJ_COLONdescribe,
       anon_sym_NULL,
-  [189] = 2,
+  [191] = 2,
     ACTIONS(84), 1,
       aux_sym_document_token1,
     ACTIONS(86), 1,
       aux_sym_filepath_token1,
-  [196] = 2,
+  [198] = 2,
     ACTIONS(84), 1,
       aux_sym_document_token1,
     ACTIONS(88), 1,
       aux_sym_text_token2,
-  [203] = 2,
+  [205] = 2,
     ACTIONS(84), 1,
       aux_sym_document_token1,
     ACTIONS(88), 1,
       aux_sym_text_token1,
-  [210] = 2,
+  [212] = 2,
     ACTIONS(90), 1,
       aux_sym_document_token1,
     ACTIONS(92), 1,
       aux_sym_filepath_token1,
-  [217] = 2,
+  [219] = 2,
     ACTIONS(94), 1,
       aux_sym_filepath_token1,
     STATE(37), 1,
       sym_filepath,
-  [224] = 1,
+  [226] = 1,
     ACTIONS(96), 1,
       aux_sym_document_token1,
-  [228] = 1,
+  [230] = 1,
     ACTIONS(98), 1,
       aux_sym_document_token1,
-  [232] = 1,
+  [234] = 1,
     ACTIONS(100), 1,
       aux_sym_document_token1,
-  [236] = 1,
+  [238] = 1,
     ACTIONS(102), 1,
       aux_sym_filepath_token1,
-  [240] = 1,
+  [242] = 1,
     ACTIONS(104), 1,
       aux_sym_filepath_token1,
-  [244] = 1,
+  [246] = 1,
     ACTIONS(106), 1,
       aux_sym_document_token1,
-  [248] = 1,
+  [250] = 1,
     ACTIONS(108), 1,
       anon_sym_SPACE,
-  [252] = 1,
+  [254] = 1,
     ACTIONS(110), 1,
       aux_sym_filepath_token1,
-  [256] = 1,
+  [258] = 1,
     ACTIONS(90), 1,
       aux_sym_document_token1,
-  [260] = 1,
+  [262] = 1,
     ACTIONS(112), 1,
       aux_sym_document_token1,
-  [264] = 1,
+  [266] = 1,
     ACTIONS(114), 1,
       aux_sym_document_token1,
-  [268] = 1,
+  [270] = 1,
     ACTIONS(116), 1,
       aux_sym_filepath_token1,
-  [272] = 1,
+  [274] = 1,
     ACTIONS(118), 1,
       aux_sym_document_token1,
-  [276] = 1,
+  [278] = 1,
     ACTIONS(120), 1,
       aux_sym_document_token1,
-  [280] = 1,
+  [282] = 1,
     ACTIONS(122), 1,
       aux_sym_document_token1,
-  [284] = 1,
+  [286] = 1,
     ACTIONS(124), 1,
       ts_builtin_sym_end,
-  [288] = 1,
+  [290] = 1,
     ACTIONS(126), 1,
       aux_sym_document_token1,
-  [292] = 1,
+  [294] = 1,
     ACTIONS(128), 1,
       aux_sym_document_token1,
 };
@@ -897,38 +925,38 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 30,
   [SMALL_STATE(4)] = 60,
   [SMALL_STATE(5)] = 72,
-  [SMALL_STATE(6)] = 84,
-  [SMALL_STATE(7)] = 96,
-  [SMALL_STATE(8)] = 108,
-  [SMALL_STATE(9)] = 120,
+  [SMALL_STATE(6)] = 86,
+  [SMALL_STATE(7)] = 98,
+  [SMALL_STATE(8)] = 110,
+  [SMALL_STATE(9)] = 122,
   [SMALL_STATE(10)] = 134,
-  [SMALL_STATE(11)] = 146,
-  [SMALL_STATE(12)] = 159,
-  [SMALL_STATE(13)] = 172,
-  [SMALL_STATE(14)] = 183,
-  [SMALL_STATE(15)] = 189,
-  [SMALL_STATE(16)] = 196,
-  [SMALL_STATE(17)] = 203,
-  [SMALL_STATE(18)] = 210,
-  [SMALL_STATE(19)] = 217,
-  [SMALL_STATE(20)] = 224,
-  [SMALL_STATE(21)] = 228,
-  [SMALL_STATE(22)] = 232,
-  [SMALL_STATE(23)] = 236,
-  [SMALL_STATE(24)] = 240,
-  [SMALL_STATE(25)] = 244,
-  [SMALL_STATE(26)] = 248,
-  [SMALL_STATE(27)] = 252,
-  [SMALL_STATE(28)] = 256,
-  [SMALL_STATE(29)] = 260,
-  [SMALL_STATE(30)] = 264,
-  [SMALL_STATE(31)] = 268,
-  [SMALL_STATE(32)] = 272,
-  [SMALL_STATE(33)] = 276,
-  [SMALL_STATE(34)] = 280,
-  [SMALL_STATE(35)] = 284,
-  [SMALL_STATE(36)] = 288,
-  [SMALL_STATE(37)] = 292,
+  [SMALL_STATE(11)] = 148,
+  [SMALL_STATE(12)] = 161,
+  [SMALL_STATE(13)] = 174,
+  [SMALL_STATE(14)] = 185,
+  [SMALL_STATE(15)] = 191,
+  [SMALL_STATE(16)] = 198,
+  [SMALL_STATE(17)] = 205,
+  [SMALL_STATE(18)] = 212,
+  [SMALL_STATE(19)] = 219,
+  [SMALL_STATE(20)] = 226,
+  [SMALL_STATE(21)] = 230,
+  [SMALL_STATE(22)] = 234,
+  [SMALL_STATE(23)] = 238,
+  [SMALL_STATE(24)] = 242,
+  [SMALL_STATE(25)] = 246,
+  [SMALL_STATE(26)] = 250,
+  [SMALL_STATE(27)] = 254,
+  [SMALL_STATE(28)] = 258,
+  [SMALL_STATE(29)] = 262,
+  [SMALL_STATE(30)] = 266,
+  [SMALL_STATE(31)] = 270,
+  [SMALL_STATE(32)] = 274,
+  [SMALL_STATE(33)] = 278,
+  [SMALL_STATE(34)] = 282,
+  [SMALL_STATE(35)] = 286,
+  [SMALL_STATE(36)] = 290,
+  [SMALL_STATE(37)] = 294,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -937,7 +965,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
   [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
   [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
   [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
@@ -946,27 +974,27 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
   [23] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
   [26] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(12),
-  [29] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
+  [29] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
   [32] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
   [35] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
   [38] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 2, 0, 0),
   [43] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 2, 0, 0),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 4, 0, 3),
-  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 4, 0, 3),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 3, 0, 1),
-  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 3, 0, 1),
-  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 5, 0, 5),
-  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 5, 0, 5),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1, 0, 0),
-  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [63] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 4, 0, 3),
+  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 4, 0, 3),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 3, 0, 1),
+  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 3, 0, 1),
+  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scissors, 5, 0, 5),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scissors, 5, 0, 5),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1, 0, 0),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
   [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
   [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
   [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
   [77] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
   [79] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_scissors_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
@@ -979,7 +1007,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__change_comment, 2, 0, 0),
   [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
   [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
   [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
   [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
@@ -988,8 +1016,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__text_comment, 2, 0, 2),
   [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_text, 3, 0, 0),
   [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
   [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__text_comment, 3, 0, 4),
   [124] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
   [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_filepath, 1, 0, 0),

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -5,6 +5,8 @@ JJ: This commit contains the following changes:
 JJ:     A .editorconfig
 JJ:     D .gitattributes
 JJ:     M .gitignore
+JJ:     C {copy_orig => copy_new}
+JJ:     R {rename_orig => rename_new}
 JJ:
 
 JJ: Lines starting with "JJ: " (like this one) will be removed.
@@ -15,6 +17,12 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
 (document
 	(comment
 		(comment_text))
+	(comment
+		(change
+			(filepath)))
+	(comment
+		(change
+			(filepath)))
 	(comment
 		(change
 			(filepath)))

--- a/test/test.jjdescription
+++ b/test/test.jjdescription
@@ -6,6 +6,8 @@ JJ: This commit contains the following changes:
 JJ:     A .editorconfig
 JJ:     D .gitattributes
 JJ:     M .gitignore
+JJ:     C {copy_orig => copy_new}
+JJ:     R {rename_orig => rename_new}
 JJ:
 
 JJ: Lines starting with "JJ: " (like this one) will be removed.


### PR DESCRIPTION
These are the "Copied" and "Renamed" change types added in jj v0.21.0.